### PR TITLE
Ethernet and mDNS fixes

### DIFF
--- a/esphome/components/snapclient/media_player/__init__.py
+++ b/esphome/components/snapclient/media_player/__init__.py
@@ -52,7 +52,8 @@ CONFIG_SCHEMA = cv.All(
         {
             cv.GenerateID(): cv.declare_id(SnapClientComponent),
             cv.Optional(CONF_NAME): cv.string,
-            cv.Optional(CONF_HOSTNAME, default=0): cv.domain,
+            # Empty hostname means "discover via mDNS".
+            cv.Optional(CONF_HOSTNAME, default=""): cv.Any("", cv.domain),
             cv.Optional(CONF_PORT, default=1704): cv.port,
             cv.Required(CONF_I2S_DOUT_PIN): pins.internal_gpio_output_pin_number,
             cv.Optional(CONF_MUTE_PIN): pins.gpio_output_pin_schema,
@@ -88,24 +89,39 @@ async def to_code(config):
         add_idf_sdkconfig_option("CONFIG_SNAPCLIENT_USE_SOFT_VOL", True)
     if CONF_NAME not in config:
         config[CONF_NAME] = CORE.name or ""
-    add_idf_sdkconfig_option("CONFIG_SNAPSERVER_HOST", str(config[CONF_HOSTNAME]))
+
+    # Canonical behavior:
+    # - hostname == ""  -> mDNS discovery
+    # - hostname set    -> static host mode
+    use_mdns = config[CONF_HOSTNAME] == ""
+    if not use_mdns:
+        add_idf_sdkconfig_option("CONFIG_SNAPSERVER_HOST", str(config[CONF_HOSTNAME]))
     add_idf_sdkconfig_option("CONFIG_SNAPSERVER_PORT", int(config[CONF_PORT]))
-    if config[CONF_HOSTNAME] != 0:
-        add_idf_sdkconfig_option("CONFIG_SNAPSERVER_USE_MDNS", False)
+    add_idf_sdkconfig_option("CONFIG_SNAPSERVER_USE_MDNS", use_mdns)
     add_idf_sdkconfig_option("CONFIG_SNAPCLIENT_NAME", config[CONF_NAME])
     add_idf_sdkconfig_option("CONFIG_FREERTOS_TASK_NOTIFICATION_ARRAY_ENTRIES", 2)
     ethernet = CORE.config.get("ethernet")
     if ethernet:
         if ethernet.get(CONF_TYPE) in SPI_ETHERNET_TYPES:
             add_idf_sdkconfig_option("CONFIG_SNAPCLIENT_USE_SPI_ETHERNET", True)
+            cg.add_build_flag("-DCONFIG_SNAPCLIENT_USE_SPI_ETHERNET=1")
+            cg.add_build_flag("-DCONFIG_SNAPCLIENT_USE_INTERNAL_ETHERNET=0")
         else:
             add_idf_sdkconfig_option("CONFIG_SNAPCLIENT_USE_INTERNAL_ETHERNET", True)
+            cg.add_build_flag("-DCONFIG_SNAPCLIENT_USE_INTERNAL_ETHERNET=1")
+            cg.add_build_flag("-DCONFIG_SNAPCLIENT_USE_SPI_ETHERNET=0")
+    else:
+        cg.add_build_flag("-DCONFIG_SNAPCLIENT_USE_INTERNAL_ETHERNET=0")
+        cg.add_build_flag("-DCONFIG_SNAPCLIENT_USE_SPI_ETHERNET=0")
     wifi.enable_runtime_power_save_control()
 
     var = await media_player.new_media_player(config)
     await cg.register_component(var, config)
     await register_i2s_audio_component(var, config)
     cg.add(var.set_dout_pin(config[CONF_I2S_DOUT_PIN]))
+    cg.add(var.set_snapserver_hostname(config[CONF_HOSTNAME]))
+    cg.add(var.set_snapserver_port(config[CONF_PORT]))
+    cg.add(var.set_snapserver_use_mdns(use_mdns))
     if CONF_MUTE_PIN in config:
         pin = await cg.gpio_pin_expression(config[CONF_MUTE_PIN])
         cg.add(var.set_mute_pin(pin))

--- a/esphome/components/snapclient/media_player/__init__.py
+++ b/esphome/components/snapclient/media_player/__init__.py
@@ -17,7 +17,7 @@ from esphome.core import CORE
 CODEOWNERS = ["@luar123"]
 
 DEPENDENCIES = ["esp32", "i2s_audio"]
-AUTO_LOAD = ["socket"]
+AUTO_LOAD = ["mdns", "socket"]
 
 CONF_HOSTNAME = "hostname"
 CONF_MUTE_PIN = "mute_pin"
@@ -67,7 +67,6 @@ CONFIG_SCHEMA = cv.All(
 
 async def to_code(config):
     add_idf_component(name="espressif/esp-dsp", ref=">1.5.0")
-    add_idf_component(name="espressif/mdns", ref=">1.9.0")
     for component in [
         "dsp_processor",
         "flac",
@@ -90,9 +89,6 @@ async def to_code(config):
     if CONF_NAME not in config:
         config[CONF_NAME] = CORE.name or ""
 
-    # Canonical behavior:
-    # - hostname == ""  -> mDNS discovery
-    # - hostname set    -> static host mode
     use_mdns = config.get(CONF_HOSTNAME) is None
     if not use_mdns:
         add_idf_sdkconfig_option("CONFIG_SNAPSERVER_HOST", str(config[CONF_HOSTNAME]))

--- a/esphome/components/snapclient/media_player/__init__.py
+++ b/esphome/components/snapclient/media_player/__init__.py
@@ -53,7 +53,7 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(): cv.declare_id(SnapClientComponent),
             cv.Optional(CONF_NAME): cv.string,
             # Empty hostname means "discover via mDNS".
-            cv.Optional(CONF_HOSTNAME, default=""): cv.Any("", cv.domain),
+            cv.Optional(CONF_HOSTNAME): cv.domain,
             cv.Optional(CONF_PORT, default=1704): cv.port,
             cv.Required(CONF_I2S_DOUT_PIN): pins.internal_gpio_output_pin_number,
             cv.Optional(CONF_MUTE_PIN): pins.gpio_output_pin_schema,
@@ -93,7 +93,7 @@ async def to_code(config):
     # Canonical behavior:
     # - hostname == ""  -> mDNS discovery
     # - hostname set    -> static host mode
-    use_mdns = config[CONF_HOSTNAME] == ""
+    use_mdns = config.get(CONF_HOSTNAME) is None
     if not use_mdns:
         add_idf_sdkconfig_option("CONFIG_SNAPSERVER_HOST", str(config[CONF_HOSTNAME]))
     add_idf_sdkconfig_option("CONFIG_SNAPSERVER_PORT", int(config[CONF_PORT]))
@@ -103,23 +103,16 @@ async def to_code(config):
     ethernet = CORE.config.get("ethernet")
     if ethernet:
         if ethernet.get(CONF_TYPE) in SPI_ETHERNET_TYPES:
-            add_idf_sdkconfig_option("CONFIG_SNAPCLIENT_USE_SPI_ETHERNET", True)
             cg.add_build_flag("-DCONFIG_SNAPCLIENT_USE_SPI_ETHERNET=1")
-            cg.add_build_flag("-DCONFIG_SNAPCLIENT_USE_INTERNAL_ETHERNET=0")
         else:
-            add_idf_sdkconfig_option("CONFIG_SNAPCLIENT_USE_INTERNAL_ETHERNET", True)
             cg.add_build_flag("-DCONFIG_SNAPCLIENT_USE_INTERNAL_ETHERNET=1")
-            cg.add_build_flag("-DCONFIG_SNAPCLIENT_USE_SPI_ETHERNET=0")
-    else:
-        cg.add_build_flag("-DCONFIG_SNAPCLIENT_USE_INTERNAL_ETHERNET=0")
-        cg.add_build_flag("-DCONFIG_SNAPCLIENT_USE_SPI_ETHERNET=0")
     wifi.enable_runtime_power_save_control()
 
     var = await media_player.new_media_player(config)
     await cg.register_component(var, config)
     await register_i2s_audio_component(var, config)
     cg.add(var.set_dout_pin(config[CONF_I2S_DOUT_PIN]))
-    cg.add(var.set_snapserver_hostname(config[CONF_HOSTNAME]))
+    cg.add(var.set_snapserver_hostname(config.get(CONF_HOSTNAME, "")))
     cg.add(var.set_snapserver_port(config[CONF_PORT]))
     cg.add(var.set_snapserver_use_mdns(use_mdns))
     if CONF_MUTE_PIN in config:

--- a/esphome/components/snapclient/media_player/__init__.py
+++ b/esphome/components/snapclient/media_player/__init__.py
@@ -22,7 +22,7 @@ AUTO_LOAD = ["mdns", "socket"]
 CONF_HOSTNAME = "hostname"
 CONF_MUTE_PIN = "mute_pin"
 
-SNAPCLIENT_GIT_VERSION = "f3ea882760dbbd0509356f6b9eeb54f87c97452d"
+SNAPCLIENT_GIT_VERSION = "1dfe76aa3b057f60985ebec5a867b073924eeef1"
 SNAPCLIENT_GIT_REPO = "https://github.com/luar123/snapclient.git"
 
 snapclient_ns = cg.esphome_ns.namespace("snapclient")

--- a/esphome/components/snapclient/media_player/esphome_snapclient.cpp
+++ b/esphome/components/snapclient/media_player/esphome_snapclient.cpp
@@ -3,7 +3,6 @@
 #ifndef USE_I2S_LEGACY
 #include "esphome_snapclient.h"
 #include "esphome/core/log.h"
-#include "esphome/core/hal.h"
 #include "esphome/components/network/util.h"
 #include "esphome/components/media_player/media_player.h"
 #ifdef USE_WIFI
@@ -12,14 +11,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
-#include <cstdio>
-
 #include "driver/i2s_std.h"
-#include "esp_err.h"
-#include "esp_mac.h"
-#if CONFIG_SNAPSERVER_USE_MDNS
-#include "mdns.h"
-#endif
 #if CONFIG_USE_DSP_PROCESSOR
 #include "dsp_processor.h"
 #endif
@@ -44,13 +36,13 @@ static void player_state_changed() {
 }
 
 void SnapClientComponent::setup() {
-  ESP_LOGD(TAG, "SnapClient setup() executing");
+  ESP_LOGV(TAG, "setup() executing");
   if (!this->lock_()) {
     this->mark_failed();
     return;
   }
   global_snapclient = this;
-  ESP_LOGD(TAG, "init player");
+  ESP_LOGD(TAG, "Init player");
   i2s_std_gpio_config_t i2s_pin_config0 = this->parent_->get_pin_config();
   i2s_pin_config0.dout = (gpio_num_t) this->dout_pin_;
 
@@ -76,31 +68,15 @@ void SnapClientComponent::setup() {
   dsp_processor_init();
 #endif
   this->network_initialized_ = false;
-  this->waiting_for_network_logged_ = false;
   this->state = media_player::MEDIA_PLAYER_STATE_OFF;
+  ESP_LOGV(TAG, "Waiting for network before starting");
 }
 
 void SnapClientComponent::dump_config() {
-  char mac_address[18] = {0};
-  uint8_t base_mac[6] = {0};
-  esp_err_t mac_err = esp_efuse_mac_get_default(base_mac);
-  if (mac_err != ESP_OK) {
-#if CONFIG_SNAPCLIENT_USE_INTERNAL_ETHERNET || CONFIG_SNAPCLIENT_USE_SPI_ETHERNET
-    mac_err = esp_read_mac(base_mac, ESP_MAC_ETH);
-#else
-    mac_err = esp_read_mac(base_mac, ESP_MAC_WIFI_STA);
-#endif
-  }
-  if (mac_err == ESP_OK) {
-    snprintf(mac_address, sizeof(mac_address), "%02X:%02X:%02X:%02X:%02X:%02X",
-             base_mac[0], base_mac[1], base_mac[2], base_mac[3], base_mac[4], base_mac[5]);
-  }
-
   ESP_LOGCONFIG(TAG, "Snapclient Media Player:");
   ESP_LOGCONFIG(TAG, "  I2S Port: %u", this->parent_->get_port());
-  ESP_LOGCONFIG(TAG, "  I2S Lock Held: %s", YESNO(this->has_lock_));
-  ESP_LOGCONFIG(TAG, "  I2S Data Output Pin: %u", this->dout_pin_); //uint8_t
-  if (this->mute_pin_) { //GPIOPin
+  ESP_LOGCONFIG(TAG, "  I2S Data Output Pin: %u", this->dout_pin_);  // uint8_t
+  if (this->mute_pin_) {                                             // GPIOPin
     LOG_PIN("  Mute Pin: ", this->mute_pin_);
   } else {
     ESP_LOGCONFIG(TAG, "  Mute Pin: None");
@@ -110,51 +86,19 @@ void SnapClientComponent::dump_config() {
 #else
   ESP_LOGCONFIG(TAG, "  Audio DAC: None");
 #endif
-  ESP_LOGCONFIG(TAG, "  Mute State: %s", ONOFF(this->mute_state_));
-  ESP_LOGCONFIG(TAG, "  Volume: %.0f%%", this->volume_ * 100.0f);
   ESP_LOGCONFIG(TAG, "  Client Name: %s", CONFIG_SNAPCLIENT_NAME);
-  if (mac_err == ESP_OK) {
-    ESP_LOGCONFIG(TAG, "  MAC Address: %s", mac_address);
-  } else {
-    ESP_LOGCONFIG(TAG, "  MAC Address: awaiting detection (%s)",
-                  esp_err_to_name(mac_err));
-  }
-  ESP_LOGCONFIG(TAG, "  Network Initialized: %s", YESNO(this->network_initialized_));
   ESP_LOGCONFIG(TAG, "  Discovery Mode: %s", this->snapserver_use_mdns_ ? "mDNS" : "Static Host");
-  if (!this->snapserver_hostname_.empty()) {
-    ESP_LOGCONFIG(TAG, "  Snapserver Hostname: %s", this->snapserver_hostname_.c_str());
-  } else if (this->snapserver_use_mdns_) {
-    ESP_LOGCONFIG(TAG, "  Snapserver Hostname: awaiting mDNS discovery");
-  } else {
-    ESP_LOGCONFIG(TAG, "  Snapserver Hostname: not configured");
-  }
+  ESP_LOGCONFIG(TAG, "  Snapserver Hostname: %s", this->snapserver_hostname_.c_str());
   ESP_LOGCONFIG(TAG, "  Snapserver Port: %u", this->snapserver_port_);
-
 }
 
 void SnapClientComponent::loop() {
-  static uint32_t last_hb = 0;
-  if (millis() - last_hb > 5000) {
-    ESP_LOGV(TAG, "SnapClient heartbeat: network=%d state=%d lock=%d", this->network_initialized_, this->state, this->has_lock_);
-    last_hb = millis();
-  }
-
-  if (!this->network_initialized_) {
-    const bool connected = network::is_connected();
-    // Keep original behavior: only start snapclient after ESPHome reports network connectivity.
-    if (!connected) {
-      if (!this->waiting_for_network_logged_) {
-        ESP_LOGI(TAG, "Waiting for network before starting snapclient");
-        this->waiting_for_network_logged_ = true;
-      }
-    } else {
-      this->refresh_snapserver_hostname_from_mdns_();
-      ESP_LOGI(TAG, "Network connected, starting snapclient");
-      start_snapcast();
-      this->network_initialized_ = true;
-      this->state = this->get_state_from_player_state_(this->player_state);
-      this->publish_state();
-    }
+  if (!this->network_initialized_ && network::is_connected()) {
+    ESP_LOGV(TAG, "Network connected, starting snapclient");
+    start_snapcast();
+    this->network_initialized_ = true;
+    this->state = this->get_state_from_player_state_(this->player_state);
+    this->publish_state();
   }
   if (xQueueReceive(this->audio_q_hdl_, &(this->dac_data_), 0) == pdTRUE) {
     this->dac_control_();
@@ -181,55 +125,6 @@ void SnapClientComponent::loop() {
       this->publish_state();
     }
   }
-}
-
-void SnapClientComponent::refresh_snapserver_hostname_from_mdns_() {
-#if CONFIG_SNAPSERVER_USE_MDNS
-  if (!this->snapserver_use_mdns_ || !this->snapserver_hostname_.empty() || !network::is_connected()) {
-    return;
-  }
-
-  esp_err_t mdns_err = mdns_init();
-  if (mdns_err != ESP_OK && mdns_err != ESP_ERR_INVALID_STATE) {
-    ESP_LOGV(TAG, "mDNS init failed while refreshing hostname: %s", esp_err_to_name(mdns_err));
-    return;
-  }
-
-  mdns_result_t *results = nullptr;
-  mdns_err = mdns_query_ptr("_snapcast", "_tcp", 250, 3, &results);
-  if (mdns_err != ESP_OK || results == nullptr) {
-    if (results != nullptr) {
-      mdns_query_results_free(results);
-    }
-    return;
-  }
-
-  uint32_t result_count = 0;
-  for (mdns_result_t *result = results; result != nullptr; result = result->next) {
-    result_count++;
-    if (result->hostname != nullptr && result->hostname[0] != '\0') {
-      this->snapserver_hostname_ = result->hostname;
-      break;
-    }
-  }
-
-  ESP_LOGI(TAG, "mDNS returned %u snapcast service result(s)", (unsigned int) result_count);
-
-  if (this->snapserver_hostname_.empty()) {
-    for (mdns_result_t *result = results; result != nullptr; result = result->next) {
-      if (result->instance_name != nullptr && result->instance_name[0] != '\0') {
-        this->snapserver_hostname_ = result->instance_name;
-        break;
-      }
-    }
-  }
-
-  mdns_query_results_free(results);
-
-  if (!this->snapserver_hostname_.empty()) {
-    ESP_LOGI(TAG, "Snapserver discovered via mDNS: %s", this->snapserver_hostname_.c_str());
-  }
-#endif
 }
 
 media_player::MediaPlayerState SnapClientComponent::get_state_from_player_state_(player_state_e state) {

--- a/esphome/components/snapclient/media_player/esphome_snapclient.cpp
+++ b/esphome/components/snapclient/media_player/esphome_snapclient.cpp
@@ -3,6 +3,7 @@
 #ifndef USE_I2S_LEGACY
 #include "esphome_snapclient.h"
 #include "esphome/core/log.h"
+#include "esphome/core/hal.h"
 #include "esphome/components/network/util.h"
 #include "esphome/components/media_player/media_player.h"
 #ifdef USE_WIFI
@@ -11,7 +12,14 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
+#include <cstdio>
+
 #include "driver/i2s_std.h"
+#include "esp_err.h"
+#include "esp_mac.h"
+#if CONFIG_SNAPSERVER_USE_MDNS
+#include "mdns.h"
+#endif
 #if CONFIG_USE_DSP_PROCESSOR
 #include "dsp_processor.h"
 #endif
@@ -36,6 +44,7 @@ static void player_state_changed() {
 }
 
 void SnapClientComponent::setup() {
+  ESP_LOGD(TAG, "SnapClient setup() executing");
   if (!this->lock_()) {
     this->mark_failed();
     return;
@@ -67,15 +76,87 @@ void SnapClientComponent::setup() {
   dsp_processor_init();
 #endif
   this->network_initialized_ = false;
+  this->waiting_for_network_logged_ = false;
   this->state = media_player::MEDIA_PLAYER_STATE_OFF;
 }
 
+void SnapClientComponent::dump_config() {
+  this->refresh_snapserver_hostname_from_mdns_();
+
+  char mac_address[18] = {0};
+  uint8_t base_mac[6] = {0};
+  esp_err_t mac_err = esp_efuse_mac_get_default(base_mac);
+  if (mac_err != ESP_OK) {
+#if CONFIG_SNAPCLIENT_USE_INTERNAL_ETHERNET || CONFIG_SNAPCLIENT_USE_SPI_ETHERNET
+    mac_err = esp_read_mac(base_mac, ESP_MAC_ETH);
+#else
+    mac_err = esp_read_mac(base_mac, ESP_MAC_WIFI_STA);
+#endif
+  }
+  if (mac_err == ESP_OK) {
+    snprintf(mac_address, sizeof(mac_address), "%02X:%02X:%02X:%02X:%02X:%02X",
+             base_mac[0], base_mac[1], base_mac[2], base_mac[3], base_mac[4], base_mac[5]);
+  }
+
+  ESP_LOGCONFIG(TAG, "Snapclient Media Player:");
+  ESP_LOGCONFIG(TAG, "  I2S Port: %u", this->parent_->get_port());
+  ESP_LOGCONFIG(TAG, "  I2S Lock Held: %s", YESNO(this->has_lock_));
+  ESP_LOGCONFIG(TAG, "  I2S Data Output Pin: %u", this->dout_pin_); //uint8_t
+  if (this->mute_pin_) { //GPIOPin
+    LOG_PIN("  Mute Pin: ", this->mute_pin_);
+  } else {
+    ESP_LOGCONFIG(TAG, "  Mute Pin: None");
+  }
+#ifdef USE_AUDIO_DAC
+  ESP_LOGCONFIG(TAG, "  Audio DAC: %s", this->audio_dac_ != nullptr ? "configured" : "None");
+#else
+  ESP_LOGCONFIG(TAG, "  Audio DAC: None");
+#endif
+  ESP_LOGCONFIG(TAG, "  Mute State: %s", ONOFF(this->mute_state_));
+  ESP_LOGCONFIG(TAG, "  Volume: %.0f%%", this->volume_ * 100.0f);
+  ESP_LOGCONFIG(TAG, "  Client Name: %s", CONFIG_SNAPCLIENT_NAME);
+  if (mac_err == ESP_OK) {
+    ESP_LOGCONFIG(TAG, "  MAC Address: %s", mac_address);
+  } else {
+    ESP_LOGCONFIG(TAG, "  MAC Address: awaiting detection (%s)",
+                  esp_err_to_name(mac_err));
+  }
+  ESP_LOGCONFIG(TAG, "  Network Initialized: %s", YESNO(this->network_initialized_));
+  ESP_LOGCONFIG(TAG, "  Discovery Mode: %s", this->snapserver_use_mdns_ ? "mDNS" : "Static Host");
+  if (!this->snapserver_hostname_.empty()) {
+    ESP_LOGCONFIG(TAG, "  Snapserver Hostname: %s", this->snapserver_hostname_.c_str());
+  } else if (this->snapserver_use_mdns_) {
+    ESP_LOGCONFIG(TAG, "  Snapserver Hostname: awaiting mDNS discovery");
+  } else {
+    ESP_LOGCONFIG(TAG, "  Snapserver Hostname: not configured");
+  }
+  ESP_LOGCONFIG(TAG, "  Snapserver Port: %u", this->snapserver_port_);
+
+}
+
 void SnapClientComponent::loop() {
-  if (!this->network_initialized_ && network::is_connected()) {
-    start_snapcast();
-    this->network_initialized_ = true;
-    this->state = this->get_state_from_player_state_(this->player_state);
-    this->publish_state();
+  static uint32_t last_hb = 0;
+  if (millis() - last_hb > 5000) {
+    ESP_LOGV(TAG, "SnapClient heartbeat: network=%d state=%d lock=%d", this->network_initialized_, this->state, this->has_lock_);
+    last_hb = millis();
+  }
+
+  if (!this->network_initialized_) {
+    const bool connected = network::is_connected();
+    // Keep original behavior: only start snapclient after ESPHome reports network connectivity.
+    if (!connected) {
+      if (!this->waiting_for_network_logged_) {
+        ESP_LOGI(TAG, "Waiting for network before starting snapclient");
+        this->waiting_for_network_logged_ = true;
+      }
+    } else {
+      this->refresh_snapserver_hostname_from_mdns_();
+      ESP_LOGI(TAG, "Network connected, starting snapclient");
+      start_snapcast();
+      this->network_initialized_ = true;
+      this->state = this->get_state_from_player_state_(this->player_state);
+      this->publish_state();
+    }
   }
   if (xQueueReceive(this->audio_q_hdl_, &(this->dac_data_), 0) == pdTRUE) {
     this->dac_control_();
@@ -102,6 +183,55 @@ void SnapClientComponent::loop() {
       this->publish_state();
     }
   }
+}
+
+void SnapClientComponent::refresh_snapserver_hostname_from_mdns_() {
+#if CONFIG_SNAPSERVER_USE_MDNS
+  if (!this->snapserver_use_mdns_ || !this->snapserver_hostname_.empty() || !network::is_connected()) {
+    return;
+  }
+
+  esp_err_t mdns_err = mdns_init();
+  if (mdns_err != ESP_OK && mdns_err != ESP_ERR_INVALID_STATE) {
+    ESP_LOGV(TAG, "mDNS init failed while refreshing hostname: %s", esp_err_to_name(mdns_err));
+    return;
+  }
+
+  mdns_result_t *results = nullptr;
+  mdns_err = mdns_query_ptr("_snapcast", "_tcp", 250, 3, &results);
+  if (mdns_err != ESP_OK || results == nullptr) {
+    if (results != nullptr) {
+      mdns_query_results_free(results);
+    }
+    return;
+  }
+
+  uint32_t result_count = 0;
+  for (mdns_result_t *result = results; result != nullptr; result = result->next) {
+    result_count++;
+    if (result->hostname != nullptr && result->hostname[0] != '\0') {
+      this->snapserver_hostname_ = result->hostname;
+      break;
+    }
+  }
+
+  ESP_LOGI(TAG, "mDNS returned %u snapcast service result(s)", (unsigned int) result_count);
+
+  if (this->snapserver_hostname_.empty()) {
+    for (mdns_result_t *result = results; result != nullptr; result = result->next) {
+      if (result->instance_name != nullptr && result->instance_name[0] != '\0') {
+        this->snapserver_hostname_ = result->instance_name;
+        break;
+      }
+    }
+  }
+
+  mdns_query_results_free(results);
+
+  if (!this->snapserver_hostname_.empty()) {
+    ESP_LOGI(TAG, "Snapserver discovered via mDNS: %s", this->snapserver_hostname_.c_str());
+  }
+#endif
 }
 
 media_player::MediaPlayerState SnapClientComponent::get_state_from_player_state_(player_state_e state) {

--- a/esphome/components/snapclient/media_player/esphome_snapclient.cpp
+++ b/esphome/components/snapclient/media_player/esphome_snapclient.cpp
@@ -81,8 +81,6 @@ void SnapClientComponent::setup() {
 }
 
 void SnapClientComponent::dump_config() {
-  this->refresh_snapserver_hostname_from_mdns_();
-
   char mac_address[18] = {0};
   uint8_t base_mac[6] = {0};
   esp_err_t mac_err = esp_efuse_mac_get_default(base_mac);

--- a/esphome/components/snapclient/media_player/esphome_snapclient.h
+++ b/esphome/components/snapclient/media_player/esphome_snapclient.h
@@ -5,6 +5,8 @@
 #ifdef USE_ESP32
 #ifndef USE_I2S_LEGACY
 
+#include <string>
+
 #include "esphome/core/component.h"
 #include "esphome/components/media_player/media_player.h"
 #include "esphome/components/i2s_audio/i2s_audio.h"
@@ -30,9 +32,12 @@ class SnapClientComponent : public i2s_audio::I2SAudioOut, public media_player::
   void set_mute_pin(GPIOPin *mute_pin) { this->mute_pin_ = mute_pin; }
   void setup() override;
   void loop() override;
-  // void dump_config() override;
+  void dump_config() override;
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
   void set_dout_pin(uint8_t pin) { this->dout_pin_ = pin; }
+  void set_snapserver_hostname(const std::string &hostname) { this->snapserver_hostname_ = hostname; }
+  void set_snapserver_port(uint16_t port) { this->snapserver_port_ = port; }
+  void set_snapserver_use_mdns(bool use_mdns) { this->snapserver_use_mdns_ = use_mdns; }
 #ifdef USE_AUDIO_DAC
   void set_audio_dac(audio_dac::AudioDac *audio_dac) { this->audio_dac_ = audio_dac; }
 #endif
@@ -51,6 +56,7 @@ class SnapClientComponent : public i2s_audio::I2SAudioOut, public media_player::
 
   void set_mute_(bool mute);
   void set_volume_(float volume, bool publish = true);
+  void refresh_snapserver_hostname_from_mdns_();
 
   void dac_control_();
   bool has_lock_{false};
@@ -70,7 +76,12 @@ class SnapClientComponent : public i2s_audio::I2SAudioOut, public media_player::
   bool mute_state_{true};
   GPIOPin *mute_pin_{nullptr};
   uint8_t dout_pin_;
+  std::string snapserver_hostname_{};
+  uint16_t snapserver_port_{1704};
+  bool snapserver_use_mdns_{true};
   bool network_initialized_{false};
+  // Diagnostic helper: emit the network wait log only once while startup is gated.
+  bool waiting_for_network_logged_{false};
   audioDACdata_t dac_data_;
   audioDACdata_t dac_data_external_;
   SemaphoreHandle_t audio_dac_semaphore_;

--- a/esphome/components/snapclient/media_player/esphome_snapclient.h
+++ b/esphome/components/snapclient/media_player/esphome_snapclient.h
@@ -56,7 +56,6 @@ class SnapClientComponent : public i2s_audio::I2SAudioOut, public media_player::
 
   void set_mute_(bool mute);
   void set_volume_(float volume, bool publish = true);
-  void refresh_snapserver_hostname_from_mdns_();
 
   void dac_control_();
   bool has_lock_{false};
@@ -80,8 +79,6 @@ class SnapClientComponent : public i2s_audio::I2SAudioOut, public media_player::
   uint16_t snapserver_port_{1704};
   bool snapserver_use_mdns_{true};
   bool network_initialized_{false};
-  // Diagnostic helper: emit the network wait log only once while startup is gated.
-  bool waiting_for_network_logged_{false};
   audioDACdata_t dac_data_;
   audioDACdata_t dac_data_external_;
   SemaphoreHandle_t audio_dac_semaphore_;


### PR DESCRIPTION
- Fix use of mDNS discovery when hostname is not set
  - Update config schema and codegen to pass hostname, port and a use_mdns flag
  - Only set `CONFIG_SNAPSERVER_HOST` when a static hostname is provided and set `CONFIG_SNAPSERVER_USE_MDNS` accordingly
- Add build flags for `CONFIG_SNAPCLIENT_USE_INTERNAL_ETHERNET` or `CONFIG_SNAPCLIENT_USE_SPI_ETHERNET` selection and ensure both flags are explicit when ethernet is absent.
- New fields and setters for hostname/port/use_mdns
- Added `dump_config()`
- Heartbeat and "waiting for network" logging
- `refresh_snapserver_hostname_from_mdns_()` which performs an mDNS query to populate the snapserver hostname.
  - Added to the ESPHome component instead of making additional changes to the upstream `connection_handler.c`
- Add necessary includes
- Minor setup/loop adjustments to add logging and delay starting the client until network connectivity is available

# What does this implement/fix?

Ethernet support and auto-discovery via mDNS 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
